### PR TITLE
fix: 升级 Docker 中 Rust 工具链以支持 2024 edition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Rust Core
-FROM rust:1.83-slim-bookworm as builder
+FROM rust:1.85-slim-bookworm as builder
 
 WORKDIR /build
 
@@ -39,31 +39,31 @@ COPY watchlist.yml .
 
 # Create a script for updating data
 RUN echo '#!/bin/bash\n\
-set -e\n\
-DB_PATH=${TIANLU_DB_PATH:-/data/tianlu_intel_v2.db}\n\
-echo "Initializing DB at $DB_PATH..."\n\
-tianlu-intel-core init-db --db "$DB_PATH"\n\
-\n\
-echo "Updating NVD..."\n\
-python -m tianlu_intel_collectors.nvd --since 7d | tianlu-intel-core ingest --source nvd --db "$DB_PATH"\n\
-\n\
-echo "Updating CISA KEV..."\n\
-python -m tianlu_intel_collectors.cisa_kev | tianlu-intel-core ingest --source cisa_kev --db "$DB_PATH"\n\
-\n\
-echo "Updating MSRC..."\n\
-python -m tianlu_intel_collectors.msrc | tianlu-intel-core ingest --source msrc --db "$DB_PATH"\n\
-\n\
-echo "Updating Exploit-DB..."\n\
-python -m tianlu_intel_collectors.exploit_db | tianlu-intel-core ingest --source exploit_db --db "$DB_PATH"\n\
-\n\
-echo "Updating EPSS..."\n\
-python -m tianlu_intel_collectors.epss | tianlu-intel-core ingest --source epss --db "$DB_PATH"\n\
-\n\
-echo "Updating GitHub PoC..."\n\
-python -m tianlu_intel_collectors.github_poc --since 7d | tianlu-intel-core ingest --source github_poc --db "$DB_PATH"\n\
-\n\
-echo "Update completed!"\n\
-' > /usr/local/bin/update-data && chmod +x /usr/local/bin/update-data
+    set -e\n\
+    DB_PATH=${TIANLU_DB_PATH:-/data/tianlu_intel_v2.db}\n\
+    echo "Initializing DB at $DB_PATH..."\n\
+    tianlu-intel-core init-db --db "$DB_PATH"\n\
+    \n\
+    echo "Updating NVD..."\n\
+    python -m tianlu_intel_collectors.nvd --since 7d | tianlu-intel-core ingest --source nvd --db "$DB_PATH"\n\
+    \n\
+    echo "Updating CISA KEV..."\n\
+    python -m tianlu_intel_collectors.cisa_kev | tianlu-intel-core ingest --source cisa_kev --db "$DB_PATH"\n\
+    \n\
+    echo "Updating MSRC..."\n\
+    python -m tianlu_intel_collectors.msrc | tianlu-intel-core ingest --source msrc --db "$DB_PATH"\n\
+    \n\
+    echo "Updating Exploit-DB..."\n\
+    python -m tianlu_intel_collectors.exploit_db | tianlu-intel-core ingest --source exploit_db --db "$DB_PATH"\n\
+    \n\
+    echo "Updating EPSS..."\n\
+    python -m tianlu_intel_collectors.epss | tianlu-intel-core ingest --source epss --db "$DB_PATH"\n\
+    \n\
+    echo "Updating GitHub PoC..."\n\
+    python -m tianlu_intel_collectors.github_poc --since 7d | tianlu-intel-core ingest --source github_poc --db "$DB_PATH"\n\
+    \n\
+    echo "Update completed!"\n\
+    ' > /usr/local/bin/update-data && chmod +x /usr/local/bin/update-data
 
 # Environment variables
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
变更
rust:1.83-slim-bookworm -> rust:1.85-slim-bookworm

经测试修改后可用及其他功能无影响

问题复现过程：
直接pull main 分支
docker-compose run --rm updater
rust构建过程中出现
4.294   Downloaded base64ct v1.8.0
4.312 error: failed to parse manifest at `/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.8.0/Cargo.toml`
4.312
4.312 Caused by:
4.312   feature `edition2024` is required
4.312
4.312   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
4.312   Consider trying a newer version of Cargo (this may require the nightly release).
4.312   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
------
Dockerfile:14

--------------------

  12 |     # Build release binary

  13 |     WORKDIR /build/tianlu-intel-core

  14 | >>> RUN cargo build --release

  15 |

  16 |     # Stage 2: Python Runtime

--------------------

failed to solve: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 101
得知1.83.0的cargo 未正式启用edition2024, 随机修改buidler镜像版本尝试